### PR TITLE
Fix to support restlets that serve static content.

### DIFF
--- a/modules/org.restlet.ext.spring/src/org/restlet/ext/spring/RestletFrameworkServlet.java
+++ b/modules/org.restlet.ext.spring/src/org/restlet/ext/spring/RestletFrameworkServlet.java
@@ -96,6 +96,35 @@ public class RestletFrameworkServlet extends FrameworkServlet {
     /** The bean name of the target Restlet. */
     private volatile String targetRestletBeanName;
 
+    /** List of supported client protocols. */
+    private volatile String clientProtocolsString;
+
+    /**
+     * Creates an implicit {@link Component} for the {@link Application}.
+     * 
+     * @return A new instance of {@link Component}
+     */
+    protected Component createComponent() {
+    	Component component = new Component();
+        if (clientProtocolsString != null) {
+            final String[] clientProtocols = clientProtocolsString
+                    .split(" ");
+            Client client;
+
+            for (final String clientProtocol : clientProtocols) {
+                client = new Client(clientProtocol);
+
+                if (client.isAvailable()) {
+                    component.getClients().add(client);
+                } else {
+                    log("[Restlet] Couldn't find a client connector for protocol "
+                            + clientProtocol);
+                }
+            }
+        }
+    	return component;
+    }
+
     /**
      * Creates the Restlet {@link Context} to use if the target application does
      * not already have a context associated, or if the target restlet is not an
@@ -106,7 +135,9 @@ public class RestletFrameworkServlet extends FrameworkServlet {
      * @return A new instance of {@link Context}
      */
     protected Context createContext() {
-        return new Context();
+    	Component component = createComponent();
+    	Context parentContext = component.getContext();
+	    return parentContext.createChildContext();
     }
 
     @Override
@@ -176,5 +207,15 @@ public class RestletFrameworkServlet extends FrameworkServlet {
      */
     public void setTargetRestletBeanName(String targetRestletBeanName) {
         this.targetRestletBeanName = targetRestletBeanName;
+    }
+
+    /**
+     * Sets the client protocols.
+     * 
+     * @param clientProtocols
+     *              Space-separated list of protocols (e.g. FILE CLAP).
+     */
+    public void setClientProtocols(String clientProtocolsString) {
+        this.clientProtocolsString = clientProtocolsString;
     }
 }

--- a/modules/org.restlet.ext.spring/src/org/restlet/ext/spring/RestletFrameworkServlet.java
+++ b/modules/org.restlet.ext.spring/src/org/restlet/ext/spring/RestletFrameworkServlet.java
@@ -120,9 +120,9 @@ public class RestletFrameworkServlet extends FrameworkServlet {
      */
     protected Component createComponent() {
         Component component;
-        if(getComponentBeanName() != null) {
+        if(componentBeanName != null) {
 	        component = (Component) getWebApplicationContext().getBean(
-	                getComponentBeanName());
+	                componentBeanName;
         } else {
 	    	component = new Component();
         }

--- a/modules/org.restlet.ext.spring/src/org/restlet/ext/spring/RestletFrameworkServlet.java
+++ b/modules/org.restlet.ext.spring/src/org/restlet/ext/spring/RestletFrameworkServlet.java
@@ -31,6 +31,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.restlet.Application;
+import org.restlet.Client;
+import org.restlet.Component;
 import org.restlet.Context;
 import org.restlet.Restlet;
 import org.restlet.ext.servlet.ServletAdapter;

--- a/modules/org.restlet.ext.spring/src/org/restlet/ext/spring/RestletFrameworkServlet.java
+++ b/modules/org.restlet.ext.spring/src/org/restlet/ext/spring/RestletFrameworkServlet.java
@@ -92,22 +92,40 @@ public class RestletFrameworkServlet extends FrameworkServlet {
 
     private static final long serialVersionUID = 1L;
 
+    /** The Component. */
+    private volatile Component component;
+
     /** The adapter of Servlet calls into Restlet equivalents. */
     private volatile ServletAdapter adapter;
 
     /** The bean name of the target Restlet. */
     private volatile String targetRestletBeanName;
 
+    /** The bean name of the Component. */
+    private volatile String componentBeanName;
+
     /** List of supported client protocols. */
     private volatile String clientProtocolsString;
 
     /**
-     * Creates an implicit {@link Component} for the {@link Application}.
+     * Creates an {@link Component} for the {@link Application}
+     * by trying to look one up from the web application context
+     * using the configured <code>componentBeanName</code>.
+     * If no component bean name is configured then a default Component is created.
+     * <p>
+     * Additionally, if any client protocols are configured via <code>clientProtocols</code>
+     * then these are also added to the component.
      * 
      * @return A new instance of {@link Component}
      */
     protected Component createComponent() {
-    	Component component = new Component();
+        Component component;
+        if(getComponentBeanName() != null) {
+	        component = (Component) getWebApplicationContext().getBean(
+	                getComponentBeanName());
+        } else {
+	    	component = new Component();
+        }
         if (clientProtocolsString != null) {
             final String[] clientProtocols = clientProtocolsString
                     .split(" ");
@@ -137,9 +155,9 @@ public class RestletFrameworkServlet extends FrameworkServlet {
      * @return A new instance of {@link Context}
      */
     protected Context createContext() {
-    	Component component = createComponent();
-    	Context parentContext = component.getContext();
-	    return parentContext.createChildContext();
+    	this.component = createComponent();
+    	Context parentContext = this.component.getContext();
+    	return parentContext.createChildContext();
     }
 
     @Override
@@ -157,6 +175,15 @@ public class RestletFrameworkServlet extends FrameworkServlet {
      */
     protected ServletAdapter getAdapter() {
         return this.adapter;
+    }
+    /**
+     * Provides access to the {@link Component} used.
+     * Exposed so that subclasses may do additional configuration.
+     * 
+     * @return The {@link Component}.
+     */
+    protected Component getComponent() {
+        return this.component;
     }
 
     /**
@@ -209,6 +236,16 @@ public class RestletFrameworkServlet extends FrameworkServlet {
      */
     public void setTargetRestletBeanName(String targetRestletBeanName) {
         this.targetRestletBeanName = targetRestletBeanName;
+    }
+
+    /**
+     * Sets the bean name of the Component.
+     * 
+     * @param componentBeanName
+     *            The bean name.
+     */
+    public void setComponentBeanName(String componentBeanName) {
+        this.componentBeanName = componentBeanName;
     }
 
     /**

--- a/modules/org.restlet.ext.spring/src/org/restlet/ext/spring/RestletFrameworkServlet.java
+++ b/modules/org.restlet.ext.spring/src/org/restlet/ext/spring/RestletFrameworkServlet.java
@@ -122,7 +122,7 @@ public class RestletFrameworkServlet extends FrameworkServlet {
         Component component;
         if(componentBeanName != null) {
 	        component = (Component) getWebApplicationContext().getBean(
-	                componentBeanName;
+	                componentBeanName);
         } else {
 	    	component = new Component();
         }


### PR DESCRIPTION
RestletFrameworkServlet fails to support restlets that serve static content due to "No ClientDispatcher". This patch fixes this by creating an implicit Component in much the same way as ServerServlet.
